### PR TITLE
Fix `merge-nodes` tool name in 1:n docs

### DIFF
--- a/docs/start/smesher/post_1n.md
+++ b/docs/start/smesher/post_1n.md
@@ -82,12 +82,12 @@ Consolidating your Spacemesh identities / PoST services onto a single node strea
 ### Step-By-Step Migration
 
 1. **Preparation** : Before starting, stop all operations on your current nodes to ensure data integrity during the migration. Make sure that all nodes _were_ running the latest version of Spacemesh newer or equal 1.4.0. This is crucial to avoid any potential issues with the migration process. Nodes that were running 1.3.x series **only** cannot be migrated directly.
-2. In the go-spacemesh release you'll find `merge-node` tool. It's a tool that allows you to merge two or more nodes into one. Currently, it assumes all or nothing during merging.
+2. In the go-spacemesh release you'll find `merge-nodes` tool. It's a tool that allows you to merge two or more nodes into one. Currently, it assumes all or nothing during merging.
 
 Run it with the following command:
 
 ```bash
-./merge-node --from <source_path> --to <target_path>
+./merge-nodes --from <source_path> --to <target_path>
 ```
 
 Where: `source_path` is the path to the node data you want to merge from and `target_path` is the path to the node data you want to merge to.


### PR DESCRIPTION
The CLI tool is actually called `merge-nodes`, not `merge-node`. This was pointed out by @hakehardware in Discord.