### PR TITLE
Integrate Google Analytics 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -52,6 +52,10 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        gtag: {
+          trackingID: 'G-2CL6HG3B96',
+          anonymizeIP: true,
+        },
       }),
     ],
   ],


### PR DESCRIPTION
This PR adds the Google Analytics tracking ID (g-tag) to the docs website. This will allow Google Analytics to track and measure website analytics (e.g., user traffic patterns, etc.).